### PR TITLE
Add altair ally to container environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ RUN mamba update --quiet --file /tmp/conda-linux-64.lock \
     && mamba clean --all -y -f \
     && fix-permissions "${CONDA_DIR}" \
     && fix-permissions "/home/${NB_USER}"
+
+RUN pip install altair_ally>=0.1.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jupyter-notebook:
-    image: stephanieta/dsci522-online-shopping-project:c47672a
+    image: stephanieta/dsci522-online-shopping-project:4956d5b
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
Altair_ally wasn't installing in our container environment, despite being listed in our environment.yaml which was used to make the conda-lock file. And the conda-lock file was used to install our packages in the container environment.

As a workaround, I added the line `RUN pip install altair_ally>=0.1.1` to our Dockerfile to explicitly install altair_ally.

Now, I'm able to rerun our analysis using the container. Lmk if it works for you too!